### PR TITLE
Refactorierung & Bugfixes: verbesserte Methodenstruktur, Check-Logik & move-Handling

### DIFF
--- a/src/Bishop.java
+++ b/src/Bishop.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import java.util.Arrays;
 
 public class Bishop extends Piece {
     public Bishop(boolean isWhite, Tile position) {
@@ -11,30 +10,23 @@ public class Bishop extends Piece {
     public void calculateNewPos() {
         //Oben-Rechts
         Tile currentTile = getPosition();
+        boolean shouldBreak;
         int newX;
         int newY;
         for (int i = 1; i < 8; i++) {
-            newY = currentTile.getY() + i;
             newX = currentTile.getX() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            newY = currentTile.getY() + i;
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
         //Oben-Links
         for (int i = 1; i < 8; i++) {
-            newY = currentTile.getY() + i;
             newX = currentTile.getX() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            newY = currentTile.getY() + i;
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -42,12 +34,8 @@ public class Bishop extends Piece {
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() + i;
             newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -55,23 +43,11 @@ public class Bishop extends Piece {
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() - i;
             newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
-    }
-
-    // Methode zum Erzeugen von FieldButtons
-    private void moveLogic(int newX, int newY){
-        Tile newTile = Board.tiles[newX][newY];
-        JButton newButton = createFieldButton(newTile);
-        Board.tiles[newX][newY].getpTile().add(newButton);
-        Board.tiles[newX][newY].getpTile().updateUI();
     }
 
     @Override

--- a/src/Board.java
+++ b/src/Board.java
@@ -844,7 +844,7 @@ public class Board {
             }
         }
         Piece.removeFieldButtons();
-        Piece.resetAllTempPieces();
+        Piece.resetTempPieces(null, Piece.ResetMode.ALL);
     }
 
     public static void getKillButtons() {
@@ -861,7 +861,7 @@ public class Board {
             }
         }
         Piece.removeFieldButtons();
-        Piece.resetAllTempPieces();
+        Piece.resetTempPieces(null, Piece.ResetMode.ALL);
     }
     
     public void createLetterRow(JPanel letterRow) {

--- a/src/Board.java
+++ b/src/Board.java
@@ -1,4 +1,3 @@
-import javax.sound.sampled.*;
 import javax.swing.*;
 import javax.swing.border.LineBorder;
 import java.awt.*;
@@ -17,7 +16,6 @@ import java.util.stream.Collectors;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.DocumentFilter;
 import javax.swing.text.AttributeSet;
-import javax.swing.text.BadLocationException;
 
 
 public class Board {
@@ -75,12 +73,8 @@ public class Board {
         gc.anchor = GridBagConstraints.LINE_START;
         innerGUI.add(numberRow, gc);
 
-        // Erstellt Letter-Row 1
-        for (int c = 97; c < 105; c++) {
-            JLabel lLetter = new JLabel((char) c + " ", SwingConstants.CENTER);
-            lLetter.setFont(new Font("Arial", Font.PLAIN, 20));
-            letterRow.add(lLetter);
-        }
+        createLetterRow(letterRow);
+        
         // Erstellt Number-Row 1
         for (int i = 8; i > 0; i--) {
             JLabel lNumber = new JLabel(" " + i + " ");
@@ -106,12 +100,8 @@ public class Board {
         gc.anchor = GridBagConstraints.LINE_END;
         innerGUI.add(numberRow1, gc);
 
-        // Erstellt Letter-Row 2
-        for (int c = 97; c < 105; c++) {
-            JLabel lLetter = new JLabel((char) c + " ", SwingConstants.CENTER);
-            lLetter.setFont(new Font("Arial", Font.PLAIN, 20));
-            letterRow1.add(lLetter);
-        }
+        createLetterRow(letterRow1);
+        
         // Erstellt Number-Row 2
         for (int i = 8; i > 0; i--) {
             JLabel lNumber = new JLabel(" " + i + "       ");
@@ -196,24 +186,7 @@ public class Board {
          */
         for (int y = 0; y < tiles.length; y++) {
             for (int x = 0; x < tiles[y].length; x++) {
-                JPanel pTile = new JPanel(new GridBagLayout());
-
-                pTile.setName(String.valueOf(x+y));
-                boolean tWhite;
-
-                /*
-                Berechnet, ob das Feld Weiß oder Schwarz sein muss. Wenn die Summe der Koordinaten eine gerade Zahl ist,
-                d. h. Rest = 0, dann ist es weiß, ist die Summe der Koordinaten eine ungerade Zahl, d. h. Rest = 1, dann
-                ist es schwarz.
-                 */
-                if ((x + y) % 2 == 0){
-                    pTile.setBackground(new Color(255, 206, 158));
-                    tWhite = true;
-                }
-                else{
-                    pTile.setBackground(new Color(209,139,71));
-                    tWhite = false;
-                }
+                JPanel pTile = getJPanel(x, y);
 
                 tiles[x][y] = new Tile(x, y, pTile);
 
@@ -226,6 +199,25 @@ public class Board {
                 chessBoard.add(tiles[x][y].getpTile());
             }
         }
+    }
+
+    private static JPanel getJPanel(int x, int y) {
+        JPanel pTile = new JPanel(new GridBagLayout());
+
+        pTile.setName(String.valueOf(x + y));
+
+                /*
+                Berechnet, ob das Feld Weiß oder Schwarz sein muss. Wenn die Summe der Koordinaten eine gerade Zahl ist,
+                d. h. Rest = 0, dann ist es weiß, ist die Summe der Koordinaten eine ungerade Zahl, d. h. Rest = 1, dann
+                ist es schwarz.
+                 */
+        if ((x + y) % 2 == 0){
+            pTile.setBackground(new Color(255, 206, 158));
+        }
+        else{
+            pTile.setBackground(new Color(209,139,71));
+        }
+        return pTile;
     }
 
     // Methode wird beim Erstellen vom Board oder beim Laden von Spielständen genutzt, um Zeit zu sparen
@@ -244,15 +236,7 @@ public class Board {
     public static void initializeBoard() {
         // Soundeffekt
         String startSfx = "src/sfx/start.wav";
-        try {
-            AudioInputStream ais = AudioSystem.getAudioInputStream(new File(startSfx));
-            Clip clip = AudioSystem.getClip();
-            clip.open(ais);
-            clip.setFramePosition(0);
-            clip.start();
-        } catch (UnsupportedAudioFileException | IOException | LineUnavailableException ex) {
-            throw new RuntimeException(ex);
-        }
+        Piece.PieceActionListener.audioPlay(startSfx);
 
         // Fügt alle Spielfiguren an ihren Startpositionen hinzu
         for (int x = 0; x < 8; x++) {
@@ -354,21 +338,25 @@ public class Board {
                 "WARNUNG", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
                     new ImageIcon("src/pics/Warning.png")) == JOptionPane.YES_OPTION) {
                         // Entfernt alle Buttons
-                        for (int i = 0; i < 8; i++) {
-                            for (int j = 0; j < 8; j++) {
-                                for (int k = 0; k < Board.tiles[i][j].getpTile().getComponents().length; k++) {
-                                    Board.tiles[i][j].getpTile().remove(k);
-                                    Board.tiles[i][j].setOccupyingPiece(null);
-                                    Board.tiles[i][j].getpTile().updateUI();
-                                }
-                            }
-                        }
-                        // Erstellt alle Buttons neu, setzt Variablen auf Startzustand zurück
+                removeALLButtons();
+                // Erstellt alle Buttons neu, setzt Variablen auf Startzustand zurück
                         setStatus(GameStatus.WHITEMOVE);
                         Board.lStatus.setText(Board.status.toString());
                         initializeBoard();
                         vCounter = 1;
                         txtA.setText("");
+            }
+        }
+
+        public static void removeALLButtons() {
+            for (int i = 0; i < 8; i++) {
+                for (int j = 0; j < 8; j++) {
+                    for (int k = 0; k < Board.tiles[i][j].getpTile().getComponents().length; k++) {
+                        Board.tiles[i][j].getpTile().remove(k);
+                        Board.tiles[i][j].setOccupyingPiece(null);
+                        Board.tiles[i][j].getpTile().updateUI();
+                    }
+                }
             }
         }
     }
@@ -486,7 +474,7 @@ public class Board {
                     writer.print(saveFile);
                     writer.close();
                 } catch (FileNotFoundException e) {
-                    e.printStackTrace();
+                    JOptionPane.showMessageDialog(null, "Fehler beim Speichern der Datei:\n" + e.getMessage(), "Fehler", JOptionPane.ERROR_MESSAGE);
                 }
             }
         }
@@ -517,15 +505,7 @@ public class Board {
                 }
 
                 // Entfernt alle Buttons auf dem Feld
-                for (int i = 0; i < 8; i++) {
-                    for (int j = 0; j < 8; j++) {
-                        for (int k = 0; k < Board.tiles[i][j].getpTile().getComponents().length; k++) {
-                            Board.tiles[i][j].getpTile().remove(k);
-                            Board.tiles[i][j].setOccupyingPiece(null);
-                            Board.tiles[i][j].getpTile().updateUI();
-                        }
-                    }
-                }
+                NewGameButtonListener.removeALLButtons();
 
                 // Liest die Pieces aus und erstellt diese
                 int sStart = fileContent.indexOf('?');
@@ -537,15 +517,7 @@ public class Board {
 
                 //Soundeffekt
                 String startSfx = "src/sfx/start.wav";
-                try {
-                    AudioInputStream ais = AudioSystem.getAudioInputStream(new File(startSfx));
-                    Clip clip = AudioSystem.getClip();
-                    clip.open(ais);
-                    clip.setFramePosition(0);
-                    clip.start();
-                } catch (UnsupportedAudioFileException | IOException | LineUnavailableException ex) {
-                    throw new RuntimeException(ex);
-                }
+                Piece.PieceActionListener.audioPlay(startSfx);
 
                 // Zählt wie viele Pieces es von einer Sorte bereits gibt
                 int bishopCounter = 0;
@@ -891,19 +863,25 @@ public class Board {
         Piece.removeFieldButtons();
         Piece.resetAllTempPieces();
     }
+    
+    public void createLetterRow(JPanel letterRow) {
+        // Erstellt Letter-Row 1
+        for (int c = 97; c < 105; c++) {
+            JLabel lLetter = new JLabel((char) c + " ", SwingConstants.CENTER);
+            lLetter.setFont(new Font("Arial", Font.PLAIN, 20));
+            letterRow.add(lLetter);
+        }
+    }
 
-    private static DocumentFilter frozenFilter = new DocumentFilter() {
+    private static final DocumentFilter frozenFilter = new DocumentFilter() {
         @Override
-        public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr)
-                throws BadLocationException {}
+        public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) {}
 
         @Override
-        public void remove(FilterBypass fb, int offset, int length)
-                throws BadLocationException {}
+        public void remove(FilterBypass fb, int offset, int length) {}
 
         @Override
-        public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs)
-                throws BadLocationException {}
+        public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) {}
     };
 
     public static void freezeTextArea() {

--- a/src/Board.java
+++ b/src/Board.java
@@ -13,9 +13,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.swing.text.AbstractDocument;
-import javax.swing.text.DocumentFilter;
-import javax.swing.text.AttributeSet;
 
 
 public class Board {
@@ -872,28 +869,6 @@ public class Board {
             letterRow.add(lLetter);
         }
     }
-
-    private static final DocumentFilter frozenFilter = new DocumentFilter() {
-        @Override
-        public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) {}
-
-        @Override
-        public void remove(FilterBypass fb, int offset, int length) {}
-
-        @Override
-        public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) {}
-    };
-
-    public static void freezeTextArea() {
-        AbstractDocument document = (AbstractDocument) txtA.getDocument();
-        document.setDocumentFilter(frozenFilter);
-    }
-
-    public static void unfreezeTextArea() {
-        AbstractDocument document = (AbstractDocument) txtA.getDocument();
-        document.setDocumentFilter(null);
-    }
-
 
     public static boolean isKingInCheck() {
         return kingInCheck;

--- a/src/King.java
+++ b/src/King.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import java.util.Arrays;
 
 public class King extends Piece {
     public King(boolean isWhite, Tile position) {

--- a/src/King.java
+++ b/src/King.java
@@ -45,18 +45,6 @@ public class King extends Piece {
         moveLogic(newX,newY);
     }
 
-    // Methode zum Erzeugen von FieldButtons
-    private void moveLogic(int newX, int newY){
-        if (isValidMove(newX, newY)){
-            Tile newTile = Board.tiles[newX][newY];
-            JButton newButton = createFieldButton(newTile);
-            Board.tiles[newX][newY].getpTile().add(newButton);
-            Board.tiles[newX][newY].getpTile().updateUI();
-        } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-            tryKill(newX,newY);
-        }
-    }
-
     // getter für, ob der König schon gecastled wurde
     public boolean isCastled() {
         return castled;

--- a/src/Knight.java
+++ b/src/Knight.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import java.util.Arrays;
 
 public class Knight extends Piece {
     public Knight(boolean isWhite, Tile position) {
@@ -28,17 +27,6 @@ public class Knight extends Piece {
             newX = currentTile.getX() - 2;
             moveLogic(newX, newY);
         }
-    }
-
-    // Methode zum Erzeugen von FieldButtons
-    private void moveLogic(int newX, int newY){
-        if (isValidMove(newX, newY)){
-            Tile newTile = Board.tiles[newX][newY];
-            JButton newButton = createFieldButton(newTile);
-            Board.tiles[newX][newY].getpTile().add(newButton);
-            Board.tiles[newX][newY].getpTile().updateUI();
-        } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-            tryKill(newX,newY);}
     }
 
     @Override

--- a/src/Pawn.java
+++ b/src/Pawn.java
@@ -1,9 +1,5 @@
-import javax.sound.sampled.*;
 import javax.swing.*;
 import java.awt.*;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
 
 // Spielfigur: Pawn / Bauer
 public class Pawn extends Piece {
@@ -67,16 +63,9 @@ public class Pawn extends Piece {
             int newX = x + i;
             if (newX < 8 && newX >= 0 && canKill(newX, y)) {
                 Piece tempPiece = Board.tiles[newX][y].getOccupyingPiece();
-                tempPieces = Arrays.copyOf(tempPieces, tempPieces.length + 1);
-                tempPieces[tempPieces.length - 1] = tempPiece;
+                tempPieces.add(tempPiece);
 
-                JButton newButton = createKillButton(Board.tiles[newX][y]);
-                newButton.setSelected(true);
-                newButton.setIcon(tempPiece.getKillIconPath(tempPiece.isWhite()));
-
-                Board.tiles[newX][y].getpTile().remove(0);
-                Board.tiles[newX][y].getpTile().add(newButton);
-                Board.tiles[newX][y].getpTile().updateUI();
+                spawnKillButton(Board.tiles[newX][y], tempPiece);
             }
         }
     }
@@ -127,15 +116,7 @@ public class Pawn extends Piece {
 
                 // Soundeffekt
                 String promotionSfx = "src/sfx/promotion.wav";
-                try {
-                    AudioInputStream ais = AudioSystem.getAudioInputStream(new File(promotionSfx));
-                    Clip clip = AudioSystem.getClip();
-                    clip.open(ais);
-                    clip.setFramePosition(0);
-                    clip.start();
-                } catch (UnsupportedAudioFileException | IOException | LineUnavailableException ex) {
-                    throw new RuntimeException(ex);
-                }
+                PieceActionListener.audioPlay(promotionSfx);
 
                 // Ausgewähltes Piece erzeugen
                 Piece promotedPiece = switch (choice) {

--- a/src/Pawn.java
+++ b/src/Pawn.java
@@ -18,22 +18,22 @@ public class Pawn extends Piece {
             int direction = isWhite() ? -1 : 1;  // Richtung hängt von der Farbe des Bauern ab
             Tile currentTile = getPosition();
             int newX = currentTile.getX();
-            int newY = currentTile.getY() + (2 * direction);
-            Tile newTile = Board.tiles[newX][newY];
+            int newY2 = currentTile.getY() + (2 * direction);
+            Tile newTile = Board.tiles[newX][newY2];
             int newY1 = currentTile.getY() + direction;
             Tile newTile1 = Board.tiles[newX][newY1];
 
             // Überprüfen, ob die neuen Positionen valide sind
-            if (isValidMove(newX, newY) && isValidMove(newX, newY1)) {
+            if (isEmptyTile(newX, newY2) && isEmptyTile(newX, newY1)) {
                 JButton newButton = createFieldButton(newTile);
-                Board.tiles[newX][newY].getpTile().add(newButton);
-                Board.tiles[newX][newY].getpTile().updateUI();
+                Board.tiles[newX][newY2].getpTile().add(newButton);
+                Board.tiles[newX][newY2].getpTile().updateUI();
                 newButton.setDefaultCapable(false);
             }
-            if (isValidMove(newX, newY1)) {
+            if (isEmptyTile(newX, newY1)) {
                 JButton newButton1 = createFieldButton(newTile1);
                 Board.tiles[newX][newY1].getpTile().add(newButton1);
-                Board.tiles[newX][newY].getpTile().updateUI();
+                Board.tiles[newX][newY2].getpTile().updateUI();
                 tryKill(newX, newY1);
             }
         } else {
@@ -45,7 +45,7 @@ public class Pawn extends Piece {
             Tile newTile = Board.tiles[newX][newY];
 
             // Überprüfen, ob die neue Position innerhalb des Spielbretts liegt
-            if (isValidMove(newX, newY)) {
+            if (isEmptyTile(newX, newY)) {
                 JButton newButton = createFieldButton(newTile);
                 Board.tiles[newX][newY].getpTile().add(newButton);
                 Board.tiles[newX][newY].getpTile().updateUI();
@@ -77,7 +77,7 @@ public class Pawn extends Piece {
             int newX = x + i;
             int newY = y + (isWhite() ? -1 : 1);
 
-            if (isValidMove(newX, newY) && canKill(newX, y)) {
+            if (isEmptyTile(newX, newY) && canKill(newX, y)) {
                 Piece tempPiece = Board.tiles[newX][y].getOccupyingPiece();
                 if (tempPiece instanceof Pawn && ((Pawn) tempPiece).isEnPassant()) {
                     // En Passant capture

--- a/src/Pawn.java
+++ b/src/Pawn.java
@@ -13,9 +13,9 @@ public class Pawn extends Piece {
     @Override
     // Methode zum Berechnen aller möglichen / erlaubten Bewegungsrichtungen dieses Figurtypen
     public void calculateNewPos() {
+        int direction = isWhite() ? -1 : 1;  // Richtung hängt von der Farbe des Bauern ab
         if (!isMoved()) {
             // Wenn der Bauer noch nicht bewegt wurde, hat er die Option, um zwei Felder zu ziehen
-            int direction = isWhite() ? -1 : 1;  // Richtung hängt von der Farbe des Bauern ab
             Tile currentTile = getPosition();
             int newX = currentTile.getX();
             int newY2 = currentTile.getY() + (2 * direction);
@@ -24,21 +24,20 @@ public class Pawn extends Piece {
             Tile newTile1 = Board.tiles[newX][newY1];
 
             // Überprüfen, ob die neuen Positionen valide sind
-            if (isEmptyTile(newX, newY2) && isEmptyTile(newX, newY1)) {
-                JButton newButton = createFieldButton(newTile);
-                Board.tiles[newX][newY2].getpTile().add(newButton);
-                Board.tiles[newX][newY2].getpTile().updateUI();
-                newButton.setDefaultCapable(false);
-            }
             if (isEmptyTile(newX, newY1)) {
                 JButton newButton1 = createFieldButton(newTile1);
                 Board.tiles[newX][newY1].getpTile().add(newButton1);
                 Board.tiles[newX][newY2].getpTile().updateUI();
                 tryKill(newX, newY1);
+                if (isEmptyTile(newX, newY2)) {
+                    JButton newButton = createFieldButton(newTile);
+                    Board.tiles[newX][newY2].getpTile().add(newButton);
+                    Board.tiles[newX][newY2].getpTile().updateUI();
+                    newButton.setDefaultCapable(false);
+                }
             }
         } else {
             // Falls der Bauer bereits bewegt wurde, kann er nur noch ein Feld ziehen
-            int direction = isWhite() ? -1 : 1;  // Richtung hängt von der Farbe des Bauern ab
             Tile currentTile = getPosition();
             int newX = currentTile.getX();
             int newY = currentTile.getY() + direction;
@@ -77,14 +76,13 @@ public class Pawn extends Piece {
             int newX = x + i;
             int newY = y + (isWhite() ? -1 : 1);
 
-            if (isEmptyTile(newX, newY) && canKill(newX, y)) {
-                Piece tempPiece = Board.tiles[newX][y].getOccupyingPiece();
-                if (tempPiece instanceof Pawn && ((Pawn) tempPiece).isEnPassant()) {
+            if (isEmptyTile(newX, newY) && canKill(newX, y) && Board.tiles[newX][y].getOccupyingPiece() instanceof Pawn pawn) {
+                if (pawn.isEnPassant()) {
                     // En Passant capture
 
                     JButton newButton = createEnPassantButton(Board.tiles[newX][newY]);
                     newButton.setSelected(true);
-                    newButton.setIcon(tempPiece.getKillIconPath(tempPiece.isWhite()));
+                    newButton.setIcon(pawn.getKillIconPath(pawn.isWhite()));
 
                     Board.tiles[newX][newY].getpTile().add(newButton);
                     Board.tiles[newX][newY].getpTile().updateUI();

--- a/src/Piece.java
+++ b/src/Piece.java
@@ -156,6 +156,23 @@ public abstract class Piece {
         } else return false;
     }
 
+    // Methode zum Erzeugen von FieldButtons
+    public boolean moveLogic(int newX, int newY) {
+        // Plan ist die Methoden aus den Subklassen zusammenzufassen und hier reinzupacken, da es an sich die selben Schritte überall sind, die nur verschiedenen in den subklassen verteilt sind
+        if (isValidMove(newX, newY)){
+            Tile newTile = Board.tiles[newX][newY];
+            JButton newButton = createFieldButton(newTile);
+            Board.tiles[newX][newY].getpTile().add(newButton);
+            Board.tiles[newX][newY].getpTile().updateUI();
+        } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
+            tryKill(newX,newY);
+            return true;
+        }else {
+            return true;
+        }
+        return false;
+    }
+
     /*-----------------------------------------Angriffs-/Schachlogik--------------------------------------------------*/
 
     // prüft, ob auf einem Feld eine gegnerische Figur ist

--- a/src/Piece.java
+++ b/src/Piece.java
@@ -150,7 +150,7 @@ public abstract class Piece {
     }
 
     // prüft, ob das jeweilige Feld im Board liegt und ob da nicht eine andere Figur schon drauf ist
-    protected static boolean isValidMove(int x, int y) {
+    protected static boolean isEmptyTile(int x, int y) {
         if (x < 8 && x > -1 && y < 8 && y > -1) {
             return Board.tiles[x][y].getOccupyingPiece() == null;
         } else return false;
@@ -159,7 +159,7 @@ public abstract class Piece {
     // Methode zum Erzeugen von FieldButtons
     public boolean moveLogic(int newX, int newY) {
         // Plan ist die Methoden aus den Subklassen zusammenzufassen und hier reinzupacken, da es an sich die selben Schritte überall sind, die nur verschiedenen in den subklassen verteilt sind
-        if (isValidMove(newX, newY)){
+        if (isEmptyTile(newX, newY)){
             Tile newTile = Board.tiles[newX][newY];
             JButton newButton = createFieldButton(newTile);
             Board.tiles[newX][newY].getpTile().add(newButton);

--- a/src/Piece.java
+++ b/src/Piece.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public abstract class Piece {
@@ -17,11 +18,18 @@ public abstract class Piece {
     public static ArrayList<Tile> almostSaviourTiles = new ArrayList<>(); // Zwischenspeicher für Tiles, die vom Verteidiger mit dem Angreifer geshared werden
     public static ArrayList<Tile> saviourTiles = new ArrayList<>(); // Speicher für Tiles, auf denen die Figur den König verteidigen kann
     public static ArrayList<Tile> nonSaviourTiles = new ArrayList<>();
+    public enum ResetMode {
+        ALL,
+        ALL_EXCEPT_DESTINATION,
+        ONLY_DESTINATION
+    }
 
     public Piece(boolean white, Tile position) {
         this.white = white;
         this.position = position;
     }
+
+    /*-----------------------------------------Getter & Setter--------------------------------------------------------*/
 
     // getter für das tile auf dem sich die Figur befindet
     public Tile getPosition() {
@@ -38,32 +46,22 @@ public abstract class Piece {
         return this.white;
     }
 
+    public abstract String getClassName(); // Für ToolTips
+
+    // Getter für "moved"-Attribut
+    public boolean isMoved() {
+        return moved;
+    }
+
+    // Setter für "moved"-Attribut
+    public void setMoved(boolean moved) {
+        this.moved = moved;
+    }
+
+    /*-----------------------------------------Bewegungslogik---------------------------------------------------------*/
+
     // abstract class spezifische methode fürs Berechnen der möglichen neuen Positionen
     public abstract void calculateNewPos();
-
-    // prüft, ob auf einem Feld eine gegnerische Figur ist
-    public boolean canKill(int x, int y) {
-        if (Board.tiles[x][y].getOccupyingPiece() != null){
-            if ((Board.tiles[x][y].getOccupyingPiece().isWhite() && isWhite())
-                    || (!Board.tiles[x][y].getOccupyingPiece().isWhite() && !isWhite())) {
-                return false;
-            } else {
-                return x < 8 && y < 8;
-            }
-        } else {
-            return false;
-        }
-    }
-
-    // erzeugt, wenn möglich killButtons an Positionen, die die Figur schlagen kann
-    public void tryKill(int x, int y) {
-        if (x >= 0 && x < 8 && canKill(x, y)) {
-            Piece tempPiece = Board.tiles[x][y].getOccupyingPiece();
-            tempPieces.add(tempPiece);
-
-            spawnKillButton(Board.tiles[x][y], tempPiece);
-        }
-    }
 
     // Methode, die die Figur auf ein neues Feld bewegt
     public void move(int newX, int newY){
@@ -132,46 +130,162 @@ public abstract class Piece {
         moved = true;
     }
 
-    // Methode, die beim castlen ausgeführt wird. Bewegt den richtigen Turm an die Stelle, an der er nach dem castlen sein müsste
-    public static void pullRook(Tile destTile){
-        if (7 - destTile.getX() < 3) { // bewegt den rechten Turm, wenn der näher am König dran ist
-            Rook rook = (Rook) Board.tiles[7][destTile.getY()].getOccupyingPiece();
-            rook.move(destTile.getX(), destTile.getY());
-        } else if (0 < destTile.getX()) { // bewegt den linken Turm, wenn der näher am König ist
-            Rook rook = (Rook) Board.tiles[0][destTile.getY()].getOccupyingPiece();
-            rook.move(destTile.getX(), destTile.getY());
+    // temporarily move a piece to a new tile without updating the game state and between moving it somewhere and back
+    // executes a given method (actionBetweenMoves)
+    public void tempMove(Piece currentPiece, Tile tempTile, Tile originalTile, Runnable actionBetweenMoves) {
+
+        Board.freezeTextArea(); // freeze txtA so move is not recorded
+        //move king to the temp position
+        currentPiece.move(tempTile.getX(), tempTile.getY());
+        Board.vCounter--; // decrease vCounter because it isn't frozen like txtA
+
+        try {
+            actionBetweenMoves.run();
+        } finally {
+            // move piece back to his original position
+            currentPiece.move(originalTile.getX(), originalTile.getY());
+            Board.unfreezeTextArea(); // unfreeze txtA
+            Board.vCounter--; // decrease vCounter because it isn't frozen like txtA
         }
     }
 
-    // Prüft, ob der König nach rechts castlen kann
-    private static void checkCastleR(Piece piece) {
-        if (piece instanceof King king && Board.tiles[7][piece.getPosition().getY()].getOccupyingPiece() instanceof Rook) {
-            // Find the rook position for castling
-            Tile rookTile = Board.tiles[7][piece.getPosition().getY()];
-            king.castle(rookTile);
+    // prüft, ob das jeweilige Feld im Board liegt und ob da nicht eine andere Figur schon drauf ist
+    protected static boolean isValidMove(int x, int y) {
+        if (x < 8 && x > -1 && y < 8 && y > -1) {
+            return Board.tiles[x][y].getOccupyingPiece() == null;
+        } else return false;
+    }
+
+    /*-----------------------------------------Angriffs-/Schachlogik--------------------------------------------------*/
+
+    // prüft, ob auf einem Feld eine gegnerische Figur ist
+    public boolean canKill(int x, int y) {
+        if (Board.tiles[x][y].getOccupyingPiece() != null){
+            if ((Board.tiles[x][y].getOccupyingPiece().isWhite() && isWhite())
+                    || (!Board.tiles[x][y].getOccupyingPiece().isWhite() && !isWhite())) {
+                return false;
+            } else {
+                return x < 8 && y < 8;
+            }
+        } else {
+            return false;
         }
     }
 
-    // Prüft, ob der König nach links castlen kann
-    private static void checkCastleL(Piece piece) {
-        if (piece instanceof King king && Board.tiles[0][piece.getPosition().getY()].getOccupyingPiece() instanceof Rook) {
-            //Find the rook position for castling
-            Tile rookTile = Board.tiles[0][piece.getPosition().getY()];
-            king.castle(rookTile);
+    // erzeugt, wenn möglich killButtons an Positionen, die die Figur schlagen kann
+    public void tryKill(int x, int y) {
+        if (x >= 0 && x < 8 && canKill(x, y)) {
+            Piece tempPiece = Board.tiles[x][y].getOccupyingPiece();
+            tempPieces.add(tempPiece);
 
+            spawnKillButton(Board.tiles[x][y], tempPiece);
         }
     }
 
-    // Methode zur Überprüfung, ob der Bauer die gegnerische Grundreihe erreicht hat
-    private void checkPromotion() {
-        if (this instanceof Pawn) {
-            int yPosition = getPosition().getY();
-            if ((yPosition == 0 && isWhite()) || (yPosition == 7 && !isWhite())) {
-                // Der Bauer hat die gegnerische Grundreihe erreicht
-                ((Pawn) this).promote();
+    // Füllt die temporären Arrays mit den möglichen neuen Positionen der aktuellen und der gefährlichen Figur und den Kill-Buttons, die currentPiece generieren kann
+    public void fillTempArrays_Check(Piece currentPiece, Piece dangerousPiece) {
+        currentPiece.calculateNewPos();
+        Board.getFieldButtons(true);
+        dangerousPiece.calculateNewPos();
+        Board.getFieldButtons(false);
+        currentPiece.calculateNewPos();
+        Board.getKillButtons();
+    }
+
+    // Findet die FieldButtonTiles, die currentPiece und dangerousPiece gemeinsam haben
+    public void findCrossingTiles_Check(boolean pieceIsKing) {
+        for (Tile defenderTile : Board.tempFieldButtonsDefender) {
+
+            boolean inAttacker = Board.tempFieldButtonsAttacker.contains(defenderTile);
+            boolean inAlmostSaviour = almostSaviourTiles.contains(defenderTile);
+            boolean inNonSaviour = nonSaviourTiles.contains(defenderTile);
+
+            // Wenn das Feld in nonSaviourTiles ist, entferne es aus almostSaviourTiles
+            if (inNonSaviour) {
+                almostSaviourTiles.remove(defenderTile);
+                continue;
+            }
+
+            // Wenn es weder in almost- noch nonSaviour ist
+            if (!inAlmostSaviour) {
+                if ((pieceIsKing && !inAttacker) || (!pieceIsKing && inAttacker)) {
+                    almostSaviourTiles.add(defenderTile);
+                } else {
+                    nonSaviourTiles.add(defenderTile);
+                }
             }
         }
     }
+
+    // Findet die Kill-Buttons, welche von currentPiece generiert wurden, die die gefährliche Figur schlagen können
+    public void findKillableTiles_Check(Piece dangerousPiece){
+        // wenn mehr als ein gefährliches Piece existiert, bringt das Killen von einem ja nichts
+        if (dangerousPieces.size() == 1) {
+            for (Tile killButtonTile : Board.tempKillButtons) {
+                if (killButtonTile == dangerousPiece.getPosition()) {
+                    for (Piece tempPiece : dangerousPieces) {
+                        if (tempPiece == dangerousPiece)
+                            continue;
+                        if (tempPiece != null && stillGeneratingKillButton(tempPiece))
+                            nonSaviourTiles.add(killButtonTile);
+                    }
+                    if (!nonSaviourTiles.contains(killButtonTile)) {
+                        saviourTiles.add(killButtonTile); //Muss nicht weiter geprüft werden, da es nur ein gefährliches Piece gibt
+                    }
+                }
+            }
+
+        }
+    }
+
+    // Prüft, ob die Tiles von almostSaviourTiles, tatsächlich den König retten können
+    public void validateAlmostSaviourTilesArray_Check(Piece currentPiece) {
+        for (Tile almostSaviourTile : almostSaviourTiles){
+            tempMove(currentPiece, almostSaviourTile, currentPiece.getPosition(), () -> {
+                if (!stillGeneratingKillButton(null)){
+                    saviourTiles.add(almostSaviourTile);
+                }else {
+                    nonSaviourTiles.add(almostSaviourTile);
+                    saviourTiles.remove(almostSaviourTile);
+                }
+            });
+        }
+    }
+
+    //fährt array aus CheckCheck() ab und schaut ob eigene Figur Pfade erzeugt, die die Pfade der Angreifer durchkreuzen oder den Angreifer schlagen könnten
+    public void chucklesImInDanger(Piece currentPiece){
+        almostSaviourTiles.clear();
+
+        for (Piece dangerousPiece : dangerousPieces) {
+            if (currentPiece.isWhite() != dangerousPiece.isWhite()){
+                fillTempArrays_Check(currentPiece, dangerousPiece);
+                findCrossingTiles_Check(false);
+                findKillableTiles_Check(dangerousPiece);
+                validateAlmostSaviourTilesArray_Check(currentPiece);
+            }
+        }
+
+        resetTempPieces(null, ResetMode.ALL);
+        removeFieldButtons();
+    }
+
+    public void safeTheKing(Piece currentPiece){
+        almostSaviourTiles.clear();
+        saviourTiles.clear();
+
+        for (Piece dangerousPiece : dangerousPieces) {
+            if (currentPiece.isWhite() != dangerousPiece.isWhite()){
+                fillTempArrays_Check(currentPiece, dangerousPiece);
+                findCrossingTiles_Check(true);
+                validateAlmostSaviourTilesArray_Check(currentPiece);
+            }
+        }
+
+        resetTempPieces(null, ResetMode.ALL);
+        removeFieldButtons();
+    }
+
+    /*-----------------------------------------GUI: Button-Erstellung-------------------------------------------------*/
 
     // Erzeugt eine Figur als Button
     public JButton createPieceButton() {
@@ -249,9 +363,205 @@ public abstract class Piece {
         return button;
     }
 
-    // abstrakte getter für die Dateipfade der dazugehörigen Bilder der Figur
-    protected abstract ImageIcon getIconPath();
-    protected abstract ImageIcon getKillIconPath(boolean white);
+    /*-----------------------------------------Statische Hilfsmethoden------------------------------------------------*/
+
+    // Prüft, ob der König nach rechts castlen kann
+    private static void checkCastleR(Piece piece) {
+        if (piece instanceof King king && Board.tiles[7][piece.getPosition().getY()].getOccupyingPiece() instanceof Rook) {
+            // Find the rook position for castling
+            Tile rookTile = Board.tiles[7][piece.getPosition().getY()];
+            king.castle(rookTile);
+        }
+    }
+
+    // Prüft, ob der König nach links castlen kann
+    private static void checkCastleL(Piece piece) {
+        if (piece instanceof King king && Board.tiles[0][piece.getPosition().getY()].getOccupyingPiece() instanceof Rook) {
+            //Find the rook position for castling
+            Tile rookTile = Board.tiles[0][piece.getPosition().getY()];
+            king.castle(rookTile);
+
+        }
+    }
+
+    // Methode, die beim castlen ausgeführt wird. Bewegt den richtigen Turm an die Stelle, an der er nach dem castlen sein müsste
+    public static void pullRook(Tile destTile){
+        if (7 - destTile.getX() < 3) { // bewegt den rechten Turm, wenn der näher am König dran ist
+            Rook rook = (Rook) Board.tiles[7][destTile.getY()].getOccupyingPiece();
+            rook.move(destTile.getX(), destTile.getY());
+        } else if (0 < destTile.getX()) { // bewegt den linken Turm, wenn der näher am König ist
+            Rook rook = (Rook) Board.tiles[0][destTile.getY()].getOccupyingPiece();
+            rook.move(destTile.getX(), destTile.getY());
+        }
+    }
+
+    // Methode zur Überprüfung, ob der Bauer die gegnerische Grundreihe erreicht hat
+    private void checkPromotion() {
+        if (this instanceof Pawn) {
+            int yPosition = getPosition().getY();
+            if ((yPosition == 0 && isWhite()) || (yPosition == 7 && !isWhite())) {
+                // Der Bauer hat die gegnerische Grundreihe erreicht
+                ((Pawn) this).promote();
+            }
+        }
+    }
+
+    // Entfernt alle Buttons auf dem Feld. for-Schleifen fahren Feld ab und entfernen ggf. den Button.
+    public static void removeFieldButtons(){
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++){
+                for (int k = 0; k < Board.tiles[i][j].getpTile().getComponents().length; k++) {
+                    Component c = Board.tiles[i][j].getpTile().getComponent(k);
+                    if (c instanceof JButton){
+                        if(((JButton) c).isSelected()){
+                            Board.tiles[i][j].getpTile().remove(k);
+                            Board.tiles[i][j].getpTile().updateUI();
+
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+
+    // fährt das tempPieces-Array ab und erzeugt an den richtigen Stellen die durch die tryKill()-Methode entfernten killbaren Pieces
+    public static void resetTempPieces(Tile destination, ResetMode mode) {
+        List<Piece> toRemove = new ArrayList<>();
+
+        for (Piece tempPiece : tempPieces) {
+            if (tempPiece == null) continue;
+
+            Tile originalTile = tempPiece.getPosition();
+
+            boolean shouldReset = switch (mode) {
+                case ALL -> true;
+                case ALL_EXCEPT_DESTINATION -> !originalTile.getpTile().equals(destination.getpTile());
+                case ONLY_DESTINATION -> originalTile.equals(destination);
+            };
+
+            if (shouldReset && originalTile != null && originalTile.getpTile() != null) {
+                if (originalTile.getpTile().getComponentCount() > 0) {
+                    originalTile.getpTile().remove(0);
+                }
+
+                originalTile.setOccupyingPiece(tempPiece);
+                JButton button = tempPiece.createPieceButton();
+                originalTile.getpTile().add(button);
+                originalTile.getpTile().updateUI();
+
+                if (mode == ResetMode.ONLY_DESTINATION) {
+                    button.setEnabled(false);
+                    button.setDisabledIcon(tempPiece.getIconPath());
+                }
+
+                toRemove.add(tempPiece);
+            }
+        }
+
+        tempPieces.removeAll(toRemove);
+        if (mode != ResetMode.ONLY_DESTINATION) {
+            tempPieces.clear();
+        }
+    }
+
+    public static Piece findKingOfActivePieces() {
+        for (int x = 0; x < 8; x++) {
+            for (int y = 0; y < 8; y++) {
+                Piece piece = Board.tiles[x][y].getOccupyingPiece();
+                if (piece instanceof King){
+                    if (piece.isWhite() && Board.status.equals(GameStatus.WHITEMOVE)) {
+                        return piece; // Return the King piece if it's the right color
+                    } else if (!piece.isWhite() && Board.status.equals(GameStatus.BLACKMOVE)) {
+                        return piece;
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException("No active King found on the board!");
+    }
+
+    //Schaut, ob King im Check steht
+    public static boolean CheckCheck(boolean isWhite) {
+        Piece kingPiece = findKingOfActivePieces();
+        Tile kingTile = kingPiece.getPosition();
+        Icon kingIcon = kingPiece.getKillIconPath(isWhite);
+        boolean check = false;
+
+        for (int m = 0; m < 8; m++) {
+            for (int n = 0; n < 8; n++) {
+                Piece piece = Board.tiles[m][n].getOccupyingPiece();
+                if (piece == null || piece.isWhite() == isWhite) continue;
+
+                piece.calculateNewPos();
+
+                if (isKingThreatenedOnTile(kingTile, kingIcon)) {
+                    if (!dangerousPieces.contains(piece)) {
+                        dangerousPieces.add(piece);
+                    }
+                    resetTempPieces(null, ResetMode.ALL);
+                    removeFieldButtons();
+                    check = true;
+                }
+
+                resetTempPieces(null, ResetMode.ALL);
+                removeFieldButtons();
+            }
+        }
+        return check;
+    }
+
+    private static boolean isKingThreatenedOnTile(Tile kingTile, Icon kingIcon) {
+        JPanel kingPanel = Board.tiles[kingTile.getX()][kingTile.getY()].getpTile();
+        for (Component c : kingPanel.getComponents()) {
+            if (c instanceof JButton button) {
+                if (Objects.equals(button.getIcon().toString(), kingIcon.toString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean stillGeneratingKillButton(Piece currentPiece){
+        Piece activeKing = findKingOfActivePieces();
+        Tile kingTile = activeKing.getPosition();
+
+        if (currentPiece != null){
+            currentPiece.calculateNewPos();
+            Board.getKillButtons();
+            for (Tile killButtonTile : Board.tempKillButtons){
+                if (killButtonTile == kingTile) {
+                    return true;
+                }
+            }
+        }else {
+            // If no specific piece is given, check all enemy pieces
+            for (int x = 0; x < 8; x++) {
+                for (int y = 0; y < 8; y++) {
+                    Piece piece = Board.tiles[x][y].getOccupyingPiece();
+                    if (piece != null && piece.isWhite() != activeKing.isWhite()) {
+                        piece.calculateNewPos();
+                        Board.getKillButtons();
+                        for (Tile killButtonTile : Board.tempKillButtons) {
+                            if (killButtonTile == kingTile) {
+                                resetTempPieces(null, ResetMode.ALL);
+                                removeFieldButtons();
+                                return true;
+                            }
+                        }
+                        resetTempPieces(null, ResetMode.ALL);
+                        removeFieldButtons();
+                    }
+                }
+            }
+        }
+        resetTempPieces(null, ResetMode.ALL);
+        removeFieldButtons();
+        return false;
+    }
+
 
     // ActionListener für, wenn Figuren gedrückt werden
     public static class PieceActionListener implements ActionListener {
@@ -268,7 +578,7 @@ public abstract class Piece {
             String clickSfx = "src/sfx/click.wav";
             audioPlay(clickSfx);
             // entfernt alle Buttons, die nur temporär sind, also keine Figuren und fügt gegebenenfalls durch killButtons entfernte Figuren wieder ein
-            resetTempPieces(piece.getPosition());
+            resetTempPieces(piece.getPosition(), ResetMode.ALL_EXCEPT_DESTINATION);
             removeFieldButtons();
             saviourTiles.clear();
             nonSaviourTiles.clear();
@@ -309,7 +619,7 @@ public abstract class Piece {
                                     Board.tiles[i][j].getpTile().updateUI();
 
                                 } else if (c instanceof JButton && ((JButton) c).isSelected() && ((JButton) c).getIcon().toString().contains("src/pics/KillTargetIcons")) {
-                                    resetThisTempPiece(Board.tiles[i][j]); // work in progress
+                                    resetTempPieces(Board.tiles[i][j], ResetMode.ONLY_DESTINATION); // work in progress
                                 }
                             }
                         }
@@ -378,7 +688,7 @@ public abstract class Piece {
                 // bewegt die Figur
                 piece.move(newTile.getX(), newTile.getY());
                 // entfernt alle Buttons, die nur temporär sind, also keine Figuren und fügt gegebenenfalls durch killButtons entfernte Figuren wieder ein
-                resetTempPieces(piece.getPosition());
+                resetTempPieces(piece.getPosition(), Piece.ResetMode.ALL_EXCEPT_DESTINATION);
                 removeFieldButtons();
 
             }
@@ -413,329 +723,10 @@ public abstract class Piece {
         }
     }
 
-    // Entfernt alle Buttons auf dem Feld. for-Schleifen fahren Feld ab und entfernen ggf. den Button.
-    public static void removeFieldButtons(){
-        for (int i = 0; i < 8; i++) {
-            for (int j = 0; j < 8; j++){
-                for (int k = 0; k < Board.tiles[i][j].getpTile().getComponents().length; k++) {
-                    Component c = Board.tiles[i][j].getpTile().getComponent(k);
-                    if (c instanceof JButton){
-                        if(((JButton) c).isSelected()){
-                            Board.tiles[i][j].getpTile().remove(k);
-                            Board.tiles[i][j].getpTile().updateUI();
+    /*-----------------------------------------Icons (abstrakt)-------------------------------------------------------*/
 
-                        }
+    // abstrakte getter für die Dateipfade der dazugehörigen Bilder der Figur
+    protected abstract ImageIcon getIconPath();
+    protected abstract ImageIcon getKillIconPath(boolean white);
 
-                    }
-                }
-            }
-        }
-    }
-
-    // fährt das tempPieces-Array ab und erzeugt an den richtigen Stellen die durch die tryKill()-Methode entfernten killbaren Pieces
-    public static void resetTempPieces(Tile destination) {
-        for (Piece tempPiece : tempPieces) {
-            if (tempPiece != null) {
-
-                Tile originalTile = tempPiece.getPosition();
-
-                if (originalTile.getpTile() != destination.getpTile()) {
-
-                    originalTile.setOccupyingPiece(tempPiece);
-
-                    JButton button = tempPiece.createPieceButton();
-                    originalTile.getpTile().remove(0);
-                    originalTile.getpTile().add(button);
-                    originalTile.getpTile().updateUI();
-                }
-            }
-        }
-
-        // Nach dem Zurücksetzen leere das tempPieces-Array
-        tempPieces.clear();
-    }
-
-    // setzt nur den KillButton zurück, der an derselben Stelle wie destination ist
-    public static void resetThisTempPiece(Tile destination) {
-        Piece piece = null;
-        for (Piece tempPiece : tempPieces) {
-            if (tempPiece != null && tempPiece.getPosition() == destination) {
-                piece = tempPiece;
-                Tile originalTile = tempPiece.getPosition();
-                originalTile.setOccupyingPiece(tempPiece);
-
-                JButton button = tempPiece.createPieceButton();
-                originalTile.getpTile().remove(0);
-                originalTile.getpTile().add(button);
-                originalTile.getpTile().updateUI();
-                button.setEnabled(false);
-                button.setDisabledIcon(tempPiece.getIconPath());
-            }
-        }
-        tempPieces.remove(piece);
-    }
-
-    // fährt das tempPieces-Array jedes Tiles ab und erzeugt an den richtigen Stellen die durch die tryKill()-Methode entfernten
-    // killbaren Pieces
-    //versuchte Lösung für CheckCheck()
-    public static void resetAllTempPieces() {
-        for (Piece tempPiece : tempPieces) {
-            if (tempPiece != null) {
-                Tile originalTile = tempPiece.getPosition();
-
-                if (originalTile != null && originalTile.getpTile() != null) {
-                    // Only remove if there are components
-                    if (originalTile.getpTile().getComponents().length > 0) {
-                        originalTile.getpTile().remove(0);
-                    }
-
-                    originalTile.setOccupyingPiece(tempPiece);
-                    JButton button = tempPiece.createPieceButton();
-                    originalTile.getpTile().add(button);
-                    originalTile.getpTile().updateUI();
-                }
-            }
-        }
-        // Clear the tempPieces array after processing
-        tempPieces.clear();
-    }
-
-    public static Piece findKingOfActivePieces() {
-        for (int x = 0; x < 8; x++) {
-            for (int y = 0; y < 8; y++) {
-                Piece piece = Board.tiles[x][y].getOccupyingPiece();
-                if (piece instanceof King){
-                    if (piece.isWhite() && Board.status.equals(GameStatus.WHITEMOVE)) {
-                        return piece; // Return the King piece if it's the right color
-                    } else if (!piece.isWhite() && Board.status.equals(GameStatus.BLACKMOVE)) {
-                        return piece;
-                    }
-                }
-            }
-        }
-        throw new IllegalStateException("No active King found on the board!");
-    }
-
-    //Schaut, ob King im Check steht
-    public static boolean CheckCheck(boolean isWhite) {
-        Piece kingPiece = findKingOfActivePieces();
-        Tile kingTile = kingPiece.getPosition();
-        Icon kingIcon = kingPiece.getKillIconPath(isWhite);
-        boolean check = false;
-
-        for (int m = 0; m < 8; m++) {
-            for (int n = 0; n < 8; n++) {
-                Piece piece = Board.tiles[m][n].getOccupyingPiece();
-                if (piece == null || piece.isWhite() == isWhite) continue;
-
-                piece.calculateNewPos();
-
-                if (isKingThreatenedOnTile(kingTile, kingIcon)) {
-                    if (!dangerousPieces.contains(piece)) {
-                        dangerousPieces.add(piece);
-                    }
-                    resetAllTempPieces();
-                    removeFieldButtons();
-                    check = true;
-                }
-
-                resetAllTempPieces();
-                removeFieldButtons();
-            }
-        }
-        return check;
-    }
-
-    private static boolean isKingThreatenedOnTile(Tile kingTile, Icon kingIcon) {
-        JPanel kingPanel = Board.tiles[kingTile.getX()][kingTile.getY()].getpTile();
-        for (Component c : kingPanel.getComponents()) {
-            if (c instanceof JButton button) {
-                if (Objects.equals(button.getIcon().toString(), kingIcon.toString())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public static boolean stillGeneratingKillButton(Piece currentPiece){
-        Piece activeKing = findKingOfActivePieces();
-        Tile kingTile = activeKing.getPosition();
-
-        if (currentPiece != null){
-            currentPiece.calculateNewPos();
-            Board.getKillButtons();
-            for (Tile killButtonTile : Board.tempKillButtons){
-                if (killButtonTile == kingTile) {
-                    return true;
-                }
-            }
-        }else {
-            // If no specific piece is given, check all enemy pieces
-            for (int x = 0; x < 8; x++) {
-                for (int y = 0; y < 8; y++) {
-                    Piece piece = Board.tiles[x][y].getOccupyingPiece();
-                    if (piece != null && piece.isWhite() != activeKing.isWhite()) {
-                        piece.calculateNewPos();
-                        Board.getKillButtons();
-                        for (Tile killButtonTile : Board.tempKillButtons) {
-                            if (killButtonTile == kingTile) {
-                                resetAllTempPieces();
-                                removeFieldButtons();
-                                return true;
-                            }
-                        }
-                        resetAllTempPieces();
-                        removeFieldButtons();
-                    }
-                }
-            }
-        }
-        resetAllTempPieces();
-        removeFieldButtons();
-        return false;
-    }
-
-    //fährt array aus CheckCheck() ab und schaut ob eigene Figur Pfade erzeugt, die die Pfade der Angreifer durchkreuzen oder den Angreifer schlagen könnten
-    public void chucklesImInDanger(Piece currentPiece){
-        almostSaviourTiles.clear();
-
-        for (Piece dangerousPiece : dangerousPieces) {
-            if (currentPiece.isWhite() != dangerousPiece.isWhite()){
-                fillTempArrays_Check(currentPiece, dangerousPiece);
-                findCrossingTiles_Check(false);
-                findKillableTiles_Check(dangerousPiece);
-                validateAlmostSaviourTilesArray_Check(currentPiece, dangerousPiece);
-            }
-        }
-
-        resetAllTempPieces();
-        removeFieldButtons();
-    }
-
-    // Füllt die temporären Arrays mit den möglichen neuen Positionen der aktuellen und der gefährlichen Figur und den Kill-Buttons, die currentPiece generieren kann
-    public void fillTempArrays_Check(Piece currentPiece, Piece dangerousPiece) {
-        currentPiece.calculateNewPos();
-        Board.getFieldButtons(true);
-        dangerousPiece.calculateNewPos();
-        Board.getFieldButtons(false);
-        currentPiece.calculateNewPos();
-        Board.getKillButtons();
-    }
-
-    // Findet die FieldButtonTiles, die currentPiece und dangerousPiece gemeinsam haben
-    public void findCrossingTiles_Check(boolean pieceIsKing) {
-        for (Tile defenderTile : Board.tempFieldButtonsDefender) {
-
-            boolean inAttacker = Board.tempFieldButtonsAttacker.contains(defenderTile);
-            boolean inAlmostSaviour = almostSaviourTiles.contains(defenderTile);
-            boolean inNonSaviour = nonSaviourTiles.contains(defenderTile);
-
-            // Wenn das Feld in nonSaviourTiles ist, entferne es aus almostSaviourTiles
-            if (inNonSaviour) {
-                almostSaviourTiles.remove(defenderTile);
-                continue;
-            }
-
-            // Wenn es weder in almost- noch nonSaviour ist
-            if (!inAlmostSaviour) {
-                if ((pieceIsKing && !inAttacker) || (!pieceIsKing && inAttacker)) {
-                    almostSaviourTiles.add(defenderTile);
-                } else {
-                    nonSaviourTiles.add(defenderTile);
-                }
-            }
-        }
-    }
-
-
-    // Findet die Kill-Buttons, welche von currentPiece generiert wurden, die die gefährliche Figur schlagen können
-    public void findKillableTiles_Check(Piece dangerousPiece){
-        // wenn mehr als ein gefährliches Piece existiert, bringt das Killen von einem ja nichts
-        if (dangerousPieces.size() == 1) {
-            for (Tile killButtonTile : Board.tempKillButtons) {
-                if (killButtonTile == dangerousPiece.getPosition()) {
-                    for (Piece tempPiece : dangerousPieces) {
-                        if (tempPiece == dangerousPiece)
-                            continue;
-                        if (tempPiece != null && stillGeneratingKillButton(tempPiece))
-                            nonSaviourTiles.add(killButtonTile);
-                    }
-                    if (!nonSaviourTiles.contains(killButtonTile)) {
-                        saviourTiles.add(killButtonTile); //Muss nicht weiter geprüft werden, da es nur ein gefährliches Piece gibt
-                    }
-                }
-            }
-
-        }
-    }
-
-    // Prüft, ob die Tiles von almostSaviourTiles, tatsächlich den König retten können
-    public void validateAlmostSaviourTilesArray_Check(Piece currentPiece, Piece dangerousPiece) {
-        for (Tile almostSaviourTile : almostSaviourTiles){
-            tempMove(currentPiece, almostSaviourTile, currentPiece.getPosition(), () -> {
-                if (!stillGeneratingKillButton(null)){
-                    saviourTiles.add(almostSaviourTile);
-                }else {
-                    nonSaviourTiles.add(almostSaviourTile);
-                    saviourTiles.remove(almostSaviourTile);
-                }
-            });
-        }
-    }
-
-    public void safeTheKing(Piece currentPiece){
-        almostSaviourTiles.clear();
-        saviourTiles.clear();
-
-        for (Piece dangerousPiece : dangerousPieces) {
-            if (currentPiece.isWhite() != dangerousPiece.isWhite()){
-                fillTempArrays_Check(currentPiece, dangerousPiece);
-                findCrossingTiles_Check(true);
-                validateAlmostSaviourTilesArray_Check(currentPiece, dangerousPiece);
-            }
-        }
-
-        resetAllTempPieces();
-        removeFieldButtons();
-    }
-
-    // temporarily move a piece to a new tile without updating the game state and between moving it somewhere and back
-    // executes a given method (actionBetweenMoves)
-    public void tempMove(Piece currentPiece, Tile tempTile, Tile originalTile, Runnable actionBetweenMoves) {
-
-        Board.freezeTextArea(); // freeze txtA so move is not recorded
-        //move king to the temp position
-        currentPiece.move(tempTile.getX(), tempTile.getY());
-        Board.vCounter--; // decrease vCounter because it isn't frozen like txtA
-
-        try {
-            actionBetweenMoves.run();
-        } finally {
-            // move piece back to his original position
-            currentPiece.move(originalTile.getX(), originalTile.getY());
-            Board.unfreezeTextArea(); // unfreeze txtA
-            Board.vCounter--; // decrease vCounter because it isn't frozen like txtA
-        }
-    }
-
-    public abstract String getClassName(); // Für ToolTips
-
-    // Getter für "moved"-Attribut
-    public boolean isMoved() {
-        return moved;
-    }
-
-    // Setter für "moved"-Attribut
-    public void setMoved(boolean moved) {
-        this.moved = moved;
-    }
-
-    // prüft, ob das jeweilige Feld im Board liegt und ob da nicht eine andere Figur schon drauf ist
-    protected static boolean isValidMove(int x, int y) {
-        if (x < 8 && x > -1 && y < 8 && y > -1) {
-            return Board.tiles[x][y].getOccupyingPiece() == null;
-        } else return false;
-    }
 }
-

--- a/src/Queen.java
+++ b/src/Queen.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import java.util.Arrays;
 
 public class Queen extends Piece {
     public Queen(boolean isWhite, Tile position) {
@@ -11,15 +10,12 @@ public class Queen extends Piece {
     public void calculateNewPos() {
         //Oben
         Tile currentTile = getPosition();
+        boolean shouldBreak;
         int newX = currentTile.getX();
         for (int i = 1; i < 8; i++) {
             int newY = currentTile.getY() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -27,12 +23,8 @@ public class Queen extends Piece {
         newX = currentTile.getX();
         for (int i = 1; i < 8; i++) {
             int newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -40,12 +32,8 @@ public class Queen extends Piece {
         int newY = currentTile.getY();
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -53,12 +41,8 @@ public class Queen extends Piece {
         newY = currentTile.getY();
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -66,12 +50,8 @@ public class Queen extends Piece {
         for (int i = 1; i < 8; i++) {
             newY = currentTile.getY() + i;
             newX = currentTile.getX() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -79,12 +59,8 @@ public class Queen extends Piece {
         for (int i = 1; i < 8; i++) {
             newY = currentTile.getY() + i;
             newX = currentTile.getX() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -92,12 +68,8 @@ public class Queen extends Piece {
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() + i;
             newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -105,23 +77,11 @@ public class Queen extends Piece {
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() - i;
             newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX,newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
-    }
-
-    // Methode zum Erzeugen von FieldButtons
-    private void moveLogic(int newX, int newY){
-        Tile newTile = Board.tiles[newX][newY];
-        JButton newButton = createFieldButton(newTile);
-        Board.tiles[newX][newY].getpTile().add(newButton);
-        Board.tiles[newX][newY].getpTile().updateUI();
     }
 
     @Override

--- a/src/Rook.java
+++ b/src/Rook.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import java.util.Arrays;
 
 public class Rook extends Piece {
     public Rook(boolean isWhite, Tile position) {
@@ -11,15 +10,12 @@ public class Rook extends Piece {
     public void calculateNewPos() {
         //Oben
         Tile currentTile = getPosition();
+        boolean shouldBreak;
         int newX = currentTile.getX();
         for (int i = 1; i < 8; i++) {
             int newY = currentTile.getY() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -27,12 +23,8 @@ public class Rook extends Piece {
         newX = currentTile.getX();
         for (int i = 1; i < 8; i++) {
             int newY = currentTile.getY() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -40,12 +32,8 @@ public class Rook extends Piece {
         int newY = currentTile.getY();
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() + i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
@@ -53,23 +41,11 @@ public class Rook extends Piece {
         newY = currentTile.getY();
         for (int i = 1; i < 8; i++) {
             newX = currentTile.getX() - i;
-            if (isValidMove(newX, newY)){
-                moveLogic(newX, newY);
-            } else if (newX < 8 && newX > -1 && newY < 8 && newY > -1){
-                tryKill(newX,newY);
-                break;
-            } else {
+            shouldBreak = moveLogic(newX, newY);
+            if (shouldBreak) {
                 break;
             }
         }
-    }
-
-    // Methode zum Erzeugen von FieldButtons
-    public void moveLogic(int newX, int newY){
-        Tile newTile = Board.tiles[newX][newY];
-        JButton newButton = createFieldButton(newTile);
-        Board.tiles[newX][newY].getpTile().add(newButton);
-        Board.tiles[newX][newY].getpTile().updateUI();
     }
 
     @Override

--- a/src/Tile.java
+++ b/src/Tile.java
@@ -43,7 +43,7 @@ public class Tile {
     public boolean isOccupied() {
         return (this.occupyingPiece != null);
     }
-    public void setOccupied(boolean occ){
+    public void setOccupied(boolean occupied){
         this.occupied = occupied;
     }
     public JButton getButton() {


### PR DESCRIPTION
Diese PR umfasst mehrere Refactorings, kleinere Fixes und Verbesserungen der Spiellogik:

Codequalität & Lesbarkeit:

tempPieces ist nun eine ArrayList – erleichtert die Handhabung.

Diverse kleinere Verbesserungen entsprechend IntelliJ-Hinweisen zur Codequalität.

Methoden wie CheckCheck(), chucklesImInDanger() und safeTheKing() überarbeitet und zur besseren Übersichtlichkeit modularisiert.

Methoden in Piece nach Funktionalität gruppiert; unnötige Redundanzen (z. B. resetTempPieces) reduziert.

Spielmechanik & Logik:

Ein Check kann nun durch das Schlagen des Angreifers aufgehoben werden – sofern nur ein Angreifer vorhanden ist.

validateAlmostSaviourTilesArray_Check() bewegt jetzt tatsächlich die Figuren.

stillGeneratingKillButton prüft nun auch allgemein auf Bedrohungen für den König (nicht nur von spezifizierten Figuren).

Methodenanpassungen:

moveLogic gibt nun einen boolean zurück, um Abbrüche in Loops zu ermöglichen; wurde zudem nach Piece verlagert.

isValidMove umbenannt zu isEmptyTile zur besseren Semantik.

CalculateNewPos in Pawn leicht korrigiert (newY → newY2).

Bugfixes:

enPassant-Fehler behoben.

move() überarbeitet: kann jetzt optional TextArea-Updates unterdrücken.

Dafür Overload eingeführt; tempMove() wurde entfernt (bei Bedarf aus altem Commit wiederherstellbar).

Auch die freeze-Methoden aus Board entfernt.